### PR TITLE
Patch/update critical dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <!-- Use UTF-8 Encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <thymeleaf.version>3.1.1.RELEASE</thymeleaf.version>
+    <thymeleaf.version>3.1.2.RELEASE</thymeleaf.version>
     <webdriver.version>5.6.3</webdriver.version>
     <webgoat.context>/</webgoat.context>
     <webgoat.sslenabled>false</webgoat.sslenabled>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <webwolf.context>/</webwolf.context>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.16</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.8.0</zxcvbn.version>
   </properties>
@@ -322,10 +322,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
`com.thoughtworks.xstream:xstream` is updated from 1.4.5 to 1.4.16 to mitigate a vulnerability that allows deserialization of untrusted data. The flaw could enable a remote attacker to execute arbitrary code by manipulating the input stream processed by the application. This update closes a potential remote code execution (RCE) vector.

`org.thymeleaf:thymeleaf` is replaced with version 3.1.2.RELEASE instead of the bundled version in `org.springframework.boot:spring-boot-starter-thymeleaf@3.1.5`. This change addresses a sandbox bypass issue where insufficient checks in the affected versions could allow an attacker to execute arbitrary code via a specially crafted HTML input.